### PR TITLE
Basic support for NXP LPCXpresso11C24 (NXP LPC11C24/301 Cortex-M0)

### DIFF
--- a/ref_app/src/mcal/lpc11c24/mcal_benchmark.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_benchmark.h
@@ -1,0 +1,26 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2014.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_BENCHMARK_2014_04_16_H_
+  #define MCAL_BENCHMARK_2014_04_16_H_
+
+  #include <cstdint>
+  #include <mcal_port.h>
+  #include <mcal_reg.h>
+
+  namespace mcal
+  {
+    namespace benchmark
+    {
+      typedef mcal::port::port_pin<std::uint32_t,
+                                   std::uint32_t,
+                                   mcal::reg::gpio0,
+                                   UINT32_C(7)> benchmark_port_type;
+    }
+  }
+
+#endif // MCAL_BENCHMARK_2014_04_16_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_config.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_config.h
@@ -1,0 +1,44 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_CONFIG_2019_06_25_H_
+  #define MCAL_BENCHMARK_2019_06_25_H_
+
+  #include <cstdint>
+  #include <mcal_osc.h>
+
+  namespace mcal
+  {
+    namespace config
+    {
+      // PLL configuration.
+      constexpr std::uint32_t fclkin       = UINT32_C(12'000'000); // Crystal Oscillator
+      constexpr std::uint32_t syspll_m     = UINT32_C(4);
+      constexpr std::uint32_t syspll_p     = UINT32_C(2);
+      constexpr std::uint32_t fclkout      = fclkin * syspll_m;
+      constexpr std::uint32_t fcco         = fclkout * 2 * syspll_p;
+
+      static_assert(fclkout <  100'000'000, "System PLL FCLKOUT cannot exceed 100MHz");
+      static_assert(   fcco >= 156'000'000, "System PLL FCCO < 156MHz");
+      static_assert(   fcco <= 320'000'000, "System PLL FCCO > 320MHz");
+
+      // System AHB clock divider.
+      constexpr std::uint32_t sysahbclkdiv = UINT32_C(1);
+
+      // System Tick configuration.
+      constexpr std::uint32_t systick_hz   = UINT32_C(10'000);
+      constexpr std::uint32_t systick_inc  = UINT32_C(100); // in microseconds
+
+      // Watchdog Timer configuration.
+      constexpr std::uint32_t wdt_osc_freq = mcal::osc::wdtlfo_osc_1_05;
+      constexpr std::uint32_t wdt_osc_div  = UINT32_C(20);
+      constexpr std::uint32_t wdt_clk_div  = UINT32_C(1);
+      constexpr std::uint32_t wdt_hz       = UINT32_C(2);   // ~2 Seconds
+    }
+  }
+
+#endif // MCAL_BENCHMARK_2019_06_25_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_cpu.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_cpu.cpp
@@ -1,0 +1,20 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <mcal_cpu.h>
+#include <mcal_osc.h>
+#include <mcal_port.h>
+#include <mcal_reg.h>
+#include <mcal_wdg.h>
+
+
+void mcal::cpu::init()
+{
+  mcal::osc::init(nullptr);
+  mcal::port::init(nullptr);
+  mcal::wdg::init(nullptr);
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_cpu.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_cpu.h
@@ -1,0 +1,145 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_CPU_2009_02_14_H_
+  #define MCAL_CPU_2009_02_14_H_
+
+  #define MY_PROGMEM
+
+  #include <cstdint>
+  #include <type_traits>
+
+  namespace mcal { namespace cpu {
+
+  void init();
+
+  inline void post_init() { }
+
+  inline void nop() { asm volatile("nop"); }
+
+  template<typename ProgramMemoryType>
+  ProgramMemoryType read_program_memory(
+    const ProgramMemoryType* pointer_to_program_memory,
+    const typename std::enable_if<(    (std::is_fundamental<ProgramMemoryType>::value == true)
+                                   && (sizeof(ProgramMemoryType) != 1U)
+                                   && (sizeof(ProgramMemoryType) != 2U)
+                                   && (sizeof(ProgramMemoryType) != 4U)
+                                   && (sizeof(ProgramMemoryType) != 8U))>::type* = nullptr)
+  {
+    using local_programmemory_type = ProgramMemoryType;
+
+    local_programmemory_type x;
+
+    for(std::size_t i = 0U; i < sizeof(local_programmemory_type); ++i)
+    {
+      const std::uint8_t next_memory_byte =
+        *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + i);
+
+      *(reinterpret_cast<std::uint8_t*>(&x) + i) = next_memory_byte;
+    }
+
+    return x;
+  }
+
+  template<typename ProgramMemoryType>
+  ProgramMemoryType read_program_memory(
+    const ProgramMemoryType* pointer_to_program_memory,
+    const typename std::enable_if<(    (std::is_fundamental<ProgramMemoryType>::value == true)
+                                   && (sizeof(ProgramMemoryType) == 1U))>::type* = nullptr)
+  {
+    using local_programmemory_type = ProgramMemoryType;
+
+    const local_programmemory_type x = *pointer_to_program_memory;
+
+    return x;
+  }
+
+  template<typename ProgramMemoryType>
+  ProgramMemoryType read_program_memory(
+    const ProgramMemoryType* pointer_to_program_memory,
+    const typename std::enable_if<(    (std::is_fundamental<ProgramMemoryType>::value == true)
+                                   && (sizeof(ProgramMemoryType) == 2U))>::type* = nullptr)
+  {
+    using local_programmemory_type = ProgramMemoryType;
+
+    const std::uint8_t memory_array[2U] =
+    {
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 0U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 1U),
+    };
+
+    local_programmemory_type x;
+
+    *(reinterpret_cast<std::uint8_t*>(&x) + 0U) = memory_array[0U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 1U) = memory_array[1U];
+
+    return x;
+  }
+
+  template<typename ProgramMemoryType>
+  ProgramMemoryType read_program_memory(
+    const ProgramMemoryType* pointer_to_program_memory,
+    const typename std::enable_if<(    (std::is_fundamental<ProgramMemoryType>::value == true)
+                                   && (sizeof(ProgramMemoryType) == 4U))>::type* = nullptr)
+  {
+    using local_programmemory_type = ProgramMemoryType;
+
+    const std::uint8_t memory_array[4U] =
+    {
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 0U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 1U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 2U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 3U),
+    };
+
+    local_programmemory_type x;
+
+    *(reinterpret_cast<std::uint8_t*>(&x) + 0U) = memory_array[0U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 1U) = memory_array[1U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 2U) = memory_array[2U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 3U) = memory_array[3U];
+
+    return x;
+  }
+
+  template<typename ProgramMemoryType>
+  ProgramMemoryType read_program_memory(
+    const ProgramMemoryType* pointer_to_program_memory,
+    const typename std::enable_if<(   (std::is_fundamental<ProgramMemoryType>::value == true)
+                                   && (sizeof(ProgramMemoryType) == 8U))>::type* = nullptr)
+  {
+    using local_programmemory_type = ProgramMemoryType;
+
+    const std::uint8_t memory_array[8U] =
+    {
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 0U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 1U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 2U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 3U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 4U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 5U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 6U),
+      *(reinterpret_cast<const std::uint8_t*>(pointer_to_program_memory) + 7U),
+    };
+
+    local_programmemory_type x;
+
+    *(reinterpret_cast<std::uint8_t*>(&x) + 0U) = memory_array[0U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 1U) = memory_array[1U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 2U) = memory_array[2U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 3U) = memory_array[3U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 4U) = memory_array[4U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 5U) = memory_array[5U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 6U) = memory_array[6U];
+    *(reinterpret_cast<std::uint8_t*>(&x) + 7U) = memory_array[7U];
+
+    return x;
+  }
+
+  } } // namespace mcal::cpu
+
+#endif // MCAL_CPU_2009_02_14_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_eep.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_eep.cpp
@@ -1,0 +1,14 @@
+#include <mcal_eep.h>
+
+void mcal::eep::write(const address_type addr, const std::uint8_t data)
+{
+  static_cast<void>(addr);
+  static_cast<void>(data);
+}
+
+std::uint8_t mcal::eep::read(const address_type addr)
+{
+  static_cast<void>(addr);
+
+  return std::uint8_t(0U);
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_eep.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_eep.h
@@ -1,0 +1,20 @@
+#ifndef MCAL_EEP_2018_12_15_H_
+  #define MCAL_EEP_2018_12_15_H_
+
+  #include <cstdint>
+
+  namespace mcal
+  {
+    namespace eep
+    {
+      using config_type  = void;
+      using address_type = std::uint32_t;
+
+      inline void init(const config_type*) { }
+
+      void         write(const address_type addr, const std::uint8_t data);
+      std::uint8_t read (const address_type addr);
+    }
+  }
+
+#endif // MCAL_EEP_2018_12_15_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_gpt.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_gpt.cpp
@@ -1,0 +1,94 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2015.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <mcal_config.h>
+#include <mcal_gpt.h>
+#include <mcal_reg.h>
+#include <mcal_irq.h>
+#include <mcal_osc.h>
+
+namespace
+{
+  // The one (and only one) system tick.
+  volatile mcal::gpt::value_type system_tick;
+
+  bool& gpt_is_initialized() __attribute__((used, noinline));
+
+  bool& gpt_is_initialized()
+  {
+    static bool is_init = bool();
+
+    return is_init;
+  }
+}
+
+extern "C" void __sys_tick_handler() __attribute__((interrupt));
+
+extern "C" void __sys_tick_handler()
+{
+  // Update 64-bit counter with microsecond count.
+  system_tick += mcal::config::systick_inc;
+}
+
+void mcal::gpt::init(const config_type*)
+{
+  if(gpt_is_initialized() == false)
+  {
+    std::uint32_t systick_load_val = (mcal::osc::get_sys_clk_rate() / mcal::config::systick_hz) & 0xFFFFFFUL;
+
+    // set reload register
+    mcal::reg::reg_access_dynamic<std::uint32_t, std::uint32_t>::reg_set(mcal::reg::systick_load, systick_load_val - 1);
+
+    // set nvic priority
+    mcal::irq::set_handler_priority(mcal::irq::systick_irqn, (1<< mcal::irq::nvic_priority_bits) - 1);
+
+    // load counter value
+    mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, mcal::reg::systick_val, 0>::reg_set();
+
+    // enable IRQ and timer
+    mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                                 mcal::reg::systick_ctrl, 
+                                 systick_ctrl_clksource | 
+                                 systick_ctrl_tickint | 
+                                 systick_ctrl_enable>::reg_set();
+
+    gpt_is_initialized() = true;
+  }
+}
+
+mcal::gpt::value_type mcal::gpt::secure::get_time_elapsed()
+{
+  if(gpt_is_initialized())
+  {
+    // Return the system tick using a multiple read to ensure data consistency.
+
+    typedef std::uint32_t timer_address_type;
+    typedef std::uint16_t timer_register_type;
+
+    // Do the first read of the systick counter and the system tick variable.
+    const timer_register_type   sys_tick_cnt_1 = mcal::reg::reg_access_static<timer_address_type, timer_register_type, mcal::reg::systick_val>::reg_get();
+    const mcal::gpt::value_type sys_tick_1 = system_tick;
+
+    // Do the second read of the systick counter.
+    const timer_register_type   sys_tick_cnt_2 = mcal::reg::reg_access_static<timer_address_type, timer_register_type, mcal::reg::systick_val>::reg_get();
+
+    // Perform the consistency check.
+    const mcal::gpt::value_type consistent_microsecond_tick
+      = ((sys_tick_cnt_2 >= sys_tick_cnt_1) ? mcal::gpt::value_type(sys_tick_1  | sys_tick_cnt_1)
+                                            : mcal::gpt::value_type(system_tick | sys_tick_cnt_2));
+
+    return consistent_microsecond_tick;
+  }
+  else
+  {
+    return mcal::gpt::value_type(0U);
+  }
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_gpt.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_gpt.h
@@ -1,0 +1,49 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2014.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_GPT_2011_10_20_H_
+  #define MCAL_GPT_2011_10_20_H_
+
+  #include <chrono>
+  #include <cstdint>
+
+  #include <util/utility/util_noexcept.h>
+
+  // Forward declaration of the util::timer template class.
+  namespace util
+  {
+    template<typename unsigned_tick_type>
+    class timer;
+  }
+
+  namespace mcal
+  {
+    namespace gpt
+    {
+      typedef void          config_type;
+      typedef std::uint64_t value_type;
+
+      void init(const config_type*);
+
+      class secure final
+      {
+        static value_type get_time_elapsed();
+
+        friend std::chrono::high_resolution_clock::time_point std::chrono::high_resolution_clock::now() UTIL_NOEXCEPT;
+
+        template<typename unsigned_tick_type>
+        friend class util::timer;
+      };
+
+      constexpr std::uint32_t systick_ctrl_enable    = UINT32_C(1UL << 0);   // 32-bit register.  enable
+      constexpr std::uint32_t systick_ctrl_tickint   = UINT32_C(1UL << 1);   // 32-bit register.  tickint
+      constexpr std::uint32_t systick_ctrl_clksource = UINT32_C(1UL << 2);   // 32-bit register.  clksource
+    }
+  }
+
+#endif // MCAL_GPT_2011_10_20_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_irq.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_irq.cpp
@@ -1,0 +1,47 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <mcal_irq.h>
+#include <mcal_reg.h>
+
+
+void mcal::irq::init(const config_type*)
+{
+  // Enable all global interrupts.
+  mcal::irq::enable_all();
+}
+
+void mcal::irq::set_handler_priority(std::int32_t irq_n, std::uint32_t priority)
+{
+  std::uint32_t shifted = ((((std::uint32_t)(irq_n)) & 0x03) * 8);
+
+  const std::uint32_t value = (((priority << (8 - nvic_priority_bits)) & 0xFF) << shifted);
+
+  const std::uint32_t mask = UINT32_C(0xFF) << shifted;
+
+
+  // Core interrupt
+  if(irq_n < 0) {
+
+    std::uint32_t idx = (((((std::uint32_t)(irq_n) & 0x0F)-8) >> 2));
+
+    const std::uint32_t address = mcal::reg::scb_shp + (idx * 4);
+
+    mcal::reg::reg_access_dynamic<std::uint32_t, std::uint32_t>::reg_msk(address, value, mask);
+  }
+
+  // Peripheral interrupt
+  else {
+
+    std::uint32_t idx = (((std::uint32_t)(irq_n) >> 2));
+
+    const std::uint32_t address = mcal::reg::nvic_ip + (idx * 4);
+
+    mcal::reg::reg_access_dynamic<std::uint32_t, std::uint32_t>::reg_msk(address, value, mask);
+  }
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_irq.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_irq.h
@@ -1,0 +1,37 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_IRQ_2010_04_10_H_
+  #define MCAL_IRQ_2010_04_10_H_
+
+  #include <cstdint>
+
+  namespace mcal
+  {
+    namespace irq
+    {
+      typedef void config_type;
+      void init(const config_type*);
+      void set_handler_priority(int32_t irq, uint32_t priority);
+
+      inline void enable_all () { asm volatile("cpsie i"); }
+      inline void disable_all() { asm volatile("cpsid i"); }
+
+      // Number of Bits NVIC uses for Priority Levels
+      constexpr std::uint32_t nvic_priority_bits = UINT32_C(2); 
+
+      // Core Interrupts
+      constexpr std::int32_t systick_irqn = INT32_C(-1);
+
+      // Peripheral Interrupts
+      constexpr std::uint32_t wdt_irqn = UINT32_C(25);
+      constexpr std::uint32_t ccan_irqn = UINT32_C(25);
+    }
+  }
+
+#endif // MCAL_IRQ_2010_04_10_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_led.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_led.cpp
@@ -1,0 +1,16 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <mcal_led.h>
+
+namespace mcal
+{
+  namespace led
+  {
+    const led_type led0;
+  }
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_led.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_led.h
@@ -1,0 +1,57 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_LED_2010_09_14_H_
+  #define MCAL_LED_2010_09_14_H_
+
+  #include <cstdint>
+  #include <mcal_port.h>
+  #include <util/utility/util_noncopyable.h>
+
+  namespace mcal
+  {
+    namespace led
+    {
+      template<typename addr_type,
+               typename reg_type,
+               const addr_type port,
+               const reg_type bpos>
+      class led final : private util::noncopyable
+      {
+      public:
+        led()
+        {
+          // Set the port pin value to low.
+          port_pin_type::set_pin_low();
+
+          // Set the port pin direction to output.
+          port_pin_type::set_direction_output();
+        }
+
+        static void toggle()
+        {
+          // Toggle the LED.
+          port_pin_type::toggle_pin();
+        }
+
+      private:
+        typedef mcal::port::port_pin<addr_type,
+                                     reg_type,
+                                     port,
+                                     bpos> port_pin_type;
+      };
+
+      typedef led<std::uint32_t,
+                  std::uint32_t,
+                  mcal::reg::gpio0,
+                  UINT32_C(8)> led_type;
+
+      extern const led_type led0;
+    }
+  }
+
+#endif // MCAL_LED_2010_09_14_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_osc.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_osc.cpp
@@ -1,0 +1,154 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2011 - 2018.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <cstdint>
+
+#include <mcal_osc.h>
+#include <mcal_reg.h>
+#include <mcal_cpu.h>
+#include <mcal_config.h>
+
+
+void mcal::osc::init(const config_type*)
+{
+  static constexpr std::uint32_t syscon_pllclksrc_mainosc_sel    = UINT32_C(1);
+  static constexpr std::uint32_t syscon_mainclksrc_pllout_sel    = UINT32_C(3);
+  static constexpr std::uint32_t flashtim_50mhz_cpu_sel          = UINT32_C(3);
+
+  static constexpr std::uint32_t syspll_m_msk                    = UINT32_C(0x1F);
+  static constexpr std::uint32_t syspll_p_msk                    = UINT32_C(0x3);
+
+
+  // Power on System Osc.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_pdruncfg, 
+                               mcal::reg::syscon_pdruncfg_sysosc_pd_bpos>::bit_clr();
+
+  // Wait for System Osc to stabilize.
+  for (volatile int i = 0; i < 0x100; i++) {}
+
+  // Select PLL Clock Source as Main OSC.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_syspllclksel, 
+                               syscon_pllclksrc_mainosc_sel>::reg_set();
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_syspllclkuen, 
+                               UINT32_C(0)>::reg_set();
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_syspllclkuen, 
+                               UINT32_C(1)>::reg_set();
+
+  // Power Off PLL.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_pdruncfg, 
+                               mcal::reg::syscon_pdruncfg_syspll_pd_bpos>::bit_set();
+
+  // Setup PLL.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_syspllctrl,
+                               (((mcal::config::syspll_m - 1) & syspll_m_msk) | 
+                               (((mcal::config::syspll_p - 1) & syspll_p_msk) << 5))>::reg_set();
+
+  // Power On PLL.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_pdruncfg, 
+                               mcal::reg::syscon_pdruncfg_syspll_pd_bpos>::bit_clr();
+
+  // Wait for PLL to lock.
+  while(
+    (mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                                  mcal::reg::syscon_syspllstat>::reg_get() & 1) == 0) { mcal::cpu::nop(); }
+
+  // Set AHB clock divider.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_sysahbclkdiv, 
+                               mcal::config::sysahbclkdiv>::reg_set();
+
+  // Set Flash wait states per system clock.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::flash_flashcfg, 
+                               flashtim_50mhz_cpu_sel>::reg_msk<UINT32_C(0x03)>();
+
+  // Set Main Clock as PLL out.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_mainclksel, 
+                               syscon_mainclksrc_pllout_sel>::reg_set();
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_mainclkuen, 
+                               UINT32_C(0)>::reg_set();
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_mainclkuen, 
+                               UINT32_C(1)>::reg_set();
+
+  // Enable IOCON Clock.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_sysahbclkctrl, 
+                               mcal::reg::syscon_clock_iocon>::reg_or();
+}
+
+std::uint32_t mcal::osc::get_sys_clk_rate()
+{
+	uint32_t clk_rate = 0;
+
+  switch(mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                              mcal::reg::syscon_mainclksel>::reg_get() & 0x3) {
+
+    case syscon_mainclksel_irc:
+    case syscon_mainclksel_pllin:
+      clk_rate = mcal::config::fclkin;
+      break;
+    case syscon_mainclksel_wdtosc:
+      clk_rate = mcal::osc::get_wdt_osc_rate();
+      break;
+    case syscon_mainclksel_pllout:
+      clk_rate = mcal::osc::get_sys_pllout_clk_rate();
+      break;
+    default:
+      clk_rate = 0;
+    }
+
+    return clk_rate /
+      mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                                   mcal::reg::syscon_sysahbclkdiv>::reg_get();
+}
+
+std::uint32_t mcal::osc::get_sys_pllout_clk_rate()
+{
+  uint32_t pll = mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                                              mcal::reg::syscon_syspllctrl>::reg_get();
+	return mcal::config::fclkin * ((pll & 0x1F) + 1);
+}
+
+void mcal::osc::set_wdt_osc(std::uint32_t freqsel, std::uint32_t divsel)
+{
+  mcal::reg::reg_access_dynamic<std::uint32_t, std::uint32_t>::reg_set(
+                                mcal::reg::syscon_wdtoscctrl,
+                                (freqsel << 5) | ((divsel >> 1) - 1));
+}
+
+void mcal::osc::set_wdt_clk_src(const std::uint32_t src, const std::uint32_t div)
+{
+  mcal::reg::reg_access_dynamic<std::uint32_t, std::uint32_t>::reg_set(mcal::reg::syscon_wdtclksel, src);
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_wdtclkuen,
+                               UINT32_C(0)>::reg_set();
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_wdtclkuen,
+                               UINT32_C(1)>::reg_set();
+
+  mcal::reg::reg_access_dynamic<std::uint32_t, std::uint32_t>::reg_set(mcal::reg::syscon_wdtclkdiv, div);
+}
+
+std::uint32_t mcal::osc::get_wdt_osc_rate()
+{
+  std::uint32_t div = mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                                                   mcal::reg::syscon_wdtoscctrl>::reg_get() & 0x1F;
+  std::uint32_t clk = ((div >> 5) & 0xF);
+
+  return wdt_osc_rate.begin()[clk] / ((div + 1) << 1);
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_osc.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_osc.h
@@ -1,0 +1,82 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_OSC_2011_10_20_H_
+  #define MCAL_OSC_2011_10_20_H_
+
+  #include <cstdint>
+  #include <initializer_list>
+
+  namespace mcal
+  {
+    namespace osc
+    {
+      typedef void config_type;
+      void init(const config_type*);
+
+      std::uint32_t get_sys_clk_rate(void);
+      std::uint32_t get_sys_pllout_clk_rate(void);
+
+      void set_wdt_osc(std::uint32_t freqsel, std::uint32_t divsel);
+      void set_wdt_clk_src(std::uint32_t src, std::uint32_t div);
+      std::uint32_t get_wdt_osc_rate(void);
+
+      // Main Clock Source Select.
+      constexpr std::uint32_t syscon_mainclksel_irc    = UINT32_C(0);
+      constexpr std::uint32_t syscon_mainclksel_pllin  = UINT32_C(1);
+      constexpr std::uint32_t syscon_mainclksel_wdtosc = UINT32_C(2);
+      constexpr std::uint32_t syscon_mainclksel_pllout = UINT32_C(3);
+
+      // PLL Clock Sources.
+      constexpr std::uint32_t syscon_pllclksrc_irc     = UINT32_C(0);
+      constexpr std::uint32_t syscon_pllclksrc_mainosc = UINT32_C(1);
+
+      // Watchdog.
+      constexpr std::uint32_t wdtlfo_osc_0_60      = UINT32_C(1);  // 0.6 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_1_05      = UINT32_C(2);	// 1.05 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_1_40      = UINT32_C(3);	// 1.4 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_1_75      = UINT32_C(4);	// 1.75 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_2_10      = UINT32_C(5);	// 2.1 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_2_40      = UINT32_C(6);	// 2.4 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_2_70      = UINT32_C(7);	// 2.7 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_3_00      = UINT32_C(8);	// 3.0 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_3_25      = UINT32_C(9);	// 3.25 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_3_50      = UINT32_C(10);	// 3.5 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_3_75      = UINT32_C(11);	// 3.75 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_4_00      = UINT32_C(12);	// 4.0 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_4_20      = UINT32_C(13);	// 4.2 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_4_40      = UINT32_C(14);	// 4.4 MHz watchdog/LFO rate
+      constexpr std::uint32_t wdtlfo_osc_4_60      = UINT32_C(15);	// 4.6 MHz watchdog/LFO rate
+
+      constexpr std::uint32_t wdtclksrc_irc        = UINT32_C(0); // Internal oscillator
+      constexpr std::uint32_t wdtclksrc_mainsysclk = UINT32_C(1); // Main system clock
+      constexpr std::uint32_t wdtclksrc_wdtosc     = UINT32_C(2); // Watchdog oscillator
+
+      constexpr std::initializer_list<std::uint32_t> wdt_osc_rate = {
+        0,
+        600000,  // wdtlfo_osc_0_60
+        1050000, // wdtlfo_osc_1_05
+        1400000, // wdtlfo_osc_1_40
+        1750000, // wdtlfo_osc_1_75
+        2100000, // wdtlfo_osc_2_10
+        2400000, // wdtlfo_osc_2_40
+        2700000, // wdtlfo_osc_2_70
+        3000000, // wdtlfo_osc_3_00
+        3250000, // wdtlfo_osc_3_25
+        3500000, // wdtlfo_osc_3_50
+        3750000, // wdtlfo_osc_3_75
+        4000000, // wdtlfo_osc_4_00
+        4200000, // wdtlfo_osc_4_20
+        4400000, // wdtlfo_osc_4_40
+        4600000  // wdtlfo_osc_4_60
+      };
+
+    }
+  }
+
+#endif // MCAL_OSC_2011_10_20_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_port.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_port.cpp
@@ -1,0 +1,19 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <mcal_port.h>
+#include <mcal_reg.h>
+
+
+void mcal::port::init(const config_type*)
+{
+  // Enable GPIO Clock.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_sysahbclkctrl,
+                               mcal::reg::syscon_clock_gpio>::reg_or();
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_port.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_port.h
@@ -1,0 +1,80 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_PORT_2019_06_21_H_
+  #define MCAL_PORT_2019_06_21_H_
+
+  #include <mcal_reg.h>
+
+  namespace mcal
+  {
+    namespace port
+    {
+      typedef void config_type;
+      void init(const config_type*);
+
+      template<typename addr_type,
+               typename reg_type,
+               const addr_type port,
+               const reg_type bpos>
+      class port_pin
+      {
+      public:
+
+        static void set_direction_output()
+        {
+          mcal::reg::reg_access_static<addr_type, reg_type,
+                                       dir_reg, bpos>::bit_set();
+        }
+
+        static void set_direction_input()
+        {
+          mcal::reg::reg_access_static<addr_type, reg_type,
+                                       dir_reg, bpos>::bit_clr();
+        }
+
+        static void set_pin_high()
+        {
+          // Set the port output value to high.
+          mcal::reg::reg_access_static<addr_type, reg_type,
+                                       data_reg, out_val_high>::reg_set();
+        }
+
+        static void set_pin_low()
+        {
+          // Set the port output value to low.
+          mcal::reg::reg_access_static<addr_type, reg_type,
+                                       data_reg, out_val_low>::reg_set();
+        }
+
+        static bool read_input_value()
+        {
+          // Read the port input value.
+          return static_cast<bool>(
+            (mcal::reg::reg_access_static<addr_type, reg_type,
+                                          data_reg>::reg_get() >> bpos) & 1);
+        }
+
+        static void toggle_pin()
+        {
+          // Toggle the port output value.
+          mcal::reg::reg_access_static<addr_type, reg_type,
+                                       data_reg, bpos>::bit_not();
+        }
+
+      private:
+        static constexpr std::uint32_t data_reg = port + (UINT32_C(4) * (1 << bpos));
+        static constexpr std::uint32_t dir_reg = port + UINT32_C(0x8000);
+
+        static constexpr std::uint32_t out_val_high = 1UL << bpos;
+        static constexpr std::uint32_t out_val_low = 0UL << bpos;
+      };
+    }
+  }
+
+#endif // MCAL_PORT_2019_06_21_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_pwm.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_pwm.cpp
@@ -1,0 +1,11 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <mcal_pwm.h>
+
+//mcal::pwm::pwm_type pwm0;
+//mcal::pwm::pwm_type pwm1;

--- a/ref_app/src/mcal/lpc11c24/mcal_pwm.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_pwm.h
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2017.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_PWM_2010_09_14_H_
+  #define MCAL_PWM_2010_09_14_H_
+
+  namespace mcal
+  {
+    namespace pwm
+    {
+      typedef void config_type;
+
+      inline void init(const config_type*) { }
+    }
+  }
+
+#endif // MCAL_PWM_2010_09_14_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_reg.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_reg.h
@@ -1,0 +1,117 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_REG_2019_06_21_H_
+  #define MCAL_REG_2019_06_21_H_
+
+  #include <cstdint>
+
+  namespace mcal
+  {
+    namespace reg
+    {
+      // C_CAN registers. 
+      constexpr std::uint32_t rom_api_can           = UINT32_C(0x1FFF334C);  
+
+      // Watchdog registers.
+      constexpr std::uint32_t wdt_mod               = UINT32_C(0x40004000);
+      constexpr std::uint32_t wdt_tc                = UINT32_C(0x40004004);
+      constexpr std::uint32_t wdt_feed              = UINT32_C(0x40004008);
+      constexpr std::uint32_t wdt_tv                = UINT32_C(0x4000400C);
+
+      // Timer registers.
+      constexpr std::uint32_t tim16_0               = UINT32_C(0x4000C000);                     
+      constexpr std::uint32_t tim16_1               = UINT32_C(0x40010000);                     
+      constexpr std::uint32_t tim32_0               = UINT32_C(0x40014000);                     
+      constexpr std::uint32_t tim32_1               = UINT32_C(0x40018000);                     
+
+      // Flash registers.
+      constexpr std::uint32_t flash_flashcfg        = UINT32_C(0x4003C010);  
+
+      // Iocon registers.
+      constexpr std::uint32_t iocon                 = UINT32_C(0x40044000);  
+
+      // Syscon registers.
+      constexpr std::uint32_t syscon_sysmemremap    = UINT32_C(0x40048000);  
+      constexpr std::uint32_t syscon_presetctrl     = UINT32_C(0x40048004);  
+      constexpr std::uint32_t syscon_syspllctrl     = UINT32_C(0x40048008);  
+      constexpr std::uint32_t syscon_syspllstat     = UINT32_C(0x4004800C);  
+      constexpr std::uint32_t syscon_syspllclksel   = UINT32_C(0x40048040);  
+      constexpr std::uint32_t syscon_wdtoscctrl     = UINT32_C(0x40048024);  
+      constexpr std::uint32_t syscon_syspllclkuen   = UINT32_C(0x40048044);  
+      constexpr std::uint32_t syscon_mainclksel     = UINT32_C(0x40048070);  
+      constexpr std::uint32_t syscon_mainclkuen     = UINT32_C(0x40048074);  
+      constexpr std::uint32_t syscon_sysahbclkdiv   = UINT32_C(0x40048078);  
+      constexpr std::uint32_t syscon_sysahbclkctrl  = UINT32_C(0x40048080);  
+      constexpr std::uint32_t syscon_wdtclksel      = UINT32_C(0x400480D0);  
+      constexpr std::uint32_t syscon_wdtclkuen      = UINT32_C(0x400480D4);  
+      constexpr std::uint32_t syscon_wdtclkdiv      = UINT32_C(0x400480D8);  
+      constexpr std::uint32_t syscon_pdruncfg       = UINT32_C(0x40048238);  
+      constexpr std::uint32_t syscon_device_id      = UINT32_C(0x400483F4);  
+
+      constexpr std::uint32_t presetctrl_ssp0_rst_n = UINT32_C(1 << 0);
+      constexpr std::uint32_t presetctrl_i2c_rst_n  = UINT32_C(1 << 1);
+      constexpr std::uint32_t presetctrl_ssp1_rst_n = UINT32_C(1 << 2);
+      constexpr std::uint32_t presetctrl_can_rst_n  = UINT32_C(1 << 3);
+
+      // System AHB Clock Control bits
+      constexpr std::uint32_t syscon_clock_sys      = UINT32_C(1 << 0);
+      constexpr std::uint32_t syscon_clock_rom      = UINT32_C(1 << 1);
+      constexpr std::uint32_t syscon_clock_ram      = UINT32_C(1 << 2);
+      constexpr std::uint32_t syscon_clock_flashreg = UINT32_C(1 << 3);
+      constexpr std::uint32_t syscon_clock_flasharray = UINT32_C(1 << 4);
+      constexpr std::uint32_t syscon_clock_i2c      = UINT32_C(1 << 5);
+      constexpr std::uint32_t syscon_clock_gpio     = UINT32_C(1 << 6);
+      constexpr std::uint32_t syscon_clock_ct16b0   = UINT32_C(1 << 7);
+      constexpr std::uint32_t syscon_clock_ct16b1   = UINT32_C(1 << 8);
+      constexpr std::uint32_t syscon_clock_ct32b0   = UINT32_C(1 << 9);
+      constexpr std::uint32_t syscon_clock_ct32b1   = UINT32_C(1 << 10);
+      constexpr std::uint32_t syscon_clock_ssp0     = UINT32_C(1 << 11);
+      constexpr std::uint32_t syscon_clock_uart0    = UINT32_C(1 << 12);
+      constexpr std::uint32_t syscon_clock_adc      = UINT32_C(1 << 13);
+      constexpr std::uint32_t syscon_clock_wdg      = UINT32_C(1 << 15);
+      constexpr std::uint32_t syscon_clock_iocon    = UINT32_C(1 << 16);
+      constexpr std::uint32_t syscon_clock_can      = UINT32_C(1 << 17);
+
+      // System Power Down bits
+      constexpr std::uint32_t syscon_pdruncfg_sysosc_pd_bpos = UINT32_C(5);
+      constexpr std::uint32_t syscon_pdruncfg_wdtosc_pd_bpos = UINT32_C(6);
+      constexpr std::uint32_t syscon_pdruncfg_syspll_pd_bpos = UINT32_C(7);
+
+      // Gpio registers.
+      constexpr std::uint32_t gpio0                 = UINT32_C(0x50000000);  
+      constexpr std::uint32_t gpio1                 = UINT32_C(0x50010000);  
+      constexpr std::uint32_t gpio2                 = UINT32_C(0x50020000);  
+      constexpr std::uint32_t gpio3                 = UINT32_C(0x50030000);  
+
+
+      // System registers.
+      constexpr std::uint32_t scb_vtor              = UINT32_C(0xE000ED08);  
+      constexpr std::uint32_t aircr                 = UINT32_C(0xE000ED0C);   // SCB application interrupt / reset control.
+
+      // System Tick registers.
+      constexpr std::uint32_t systick_ctrl          = UINT32_C(0xE000E010);  // SysTick control and status
+      constexpr std::uint32_t systick_load          = UINT32_C(0xE000E014);  // SysTick reload
+      constexpr std::uint32_t systick_val           = UINT32_C(0xE000E018);  // SysTick current value
+
+      // Interrupt control registers.
+      constexpr std::uint32_t nvic_iser             = UINT32_C(0xE000E100);  // Interrupt set enable registers.
+      constexpr std::uint32_t nvic_icer             = UINT32_C(0xE000E180);  // Interrupt clear enable registers.
+      constexpr std::uint32_t nvic_ispr             = UINT32_C(0xE000E200);  // Interrupt set pending registers.
+      constexpr std::uint32_t nvic_icpr             = UINT32_C(0xE000E280);  // Interrupt clear pending registers.
+      constexpr std::uint32_t nvic_ip               = UINT32_C(0xE000E400);  // Interrupt priority registers (each one 8 bits wide).
+
+      // System Control Block registers.
+      constexpr std::uint32_t scb_shp               = UINT32_C(0xE000ED1C);  // System control block base address
+    }
+  }
+
+  #include <mcal/mcal_reg_access_dynamic.h>
+  #include <mcal/mcal_reg_access_static.h>
+
+#endif // MCAL_REG_2019_06_21_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_ser.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_ser.h
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_SER_2011_10_20_H_
+  #define MCAL_SER_2011_10_20_H_
+
+  namespace mcal
+  {
+    namespace ser
+    {
+      typedef void config_type;
+
+      inline void init(const config_type*) { }
+    }
+  }
+
+#endif // MCAL_SER_2011_10_20_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_spi.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_spi.cpp
@@ -1,0 +1,13 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2014.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <mcal_spi.h>
+
+void mcal::spi::init(const mcal::spi::config_type*)
+{
+}
+

--- a/ref_app/src/mcal/lpc11c24/mcal_spi.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_spi.h
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_SPI_2012_05_24_H_
+  #define MCAL_SPI_2012_05_24_H_
+
+  namespace mcal
+  {
+    namespace spi
+    {
+      typedef void config_type;
+
+      void init(const config_type*);
+    }
+  }
+
+#endif // MCAL_SPI_2012_05_24_H_

--- a/ref_app/src/mcal/lpc11c24/mcal_wdg.cpp
+++ b/ref_app/src/mcal/lpc11c24/mcal_wdg.cpp
@@ -1,0 +1,125 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <cstdint>
+#include <mcal_wdg.h>
+#include <mcal_reg.h>
+#include <mcal_irq.h>
+#include <mcal_osc.h>
+#include <mcal_config.h>
+
+extern "C" void __wdt_handler() __attribute__((interrupt));
+
+extern "C" void __wdt_handler()
+{
+  if(mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                                  mcal::reg::wdt_mod,
+                                  mcal::wdg::wdmod_wdtof_bpos>::bit_get()) {
+    do {
+      mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                                   mcal::reg::wdt_mod,
+                                   mcal::wdg::wdmod_wdtof_bpos>::bit_clr();
+
+    } while (mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                                          mcal::reg::wdt_mod,
+                                          mcal::wdg::wdmod_wdtof_bpos>::bit_get());
+
+    // Restart the watchdog.
+    mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                                 mcal::reg::wdt_mod,
+                                 mcal::wdg::wdmod_wden_bpos>::bit_set();
+
+    // Feed it.
+    mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                                 mcal::reg::wdt_feed,
+                                 mcal::wdg::wdt_feed_seq_1>::reg_set();
+
+    mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                                 mcal::reg::wdt_feed,
+                                 mcal::wdg::wdt_feed_seq_2>::reg_set();
+  }
+}
+
+void mcal::wdg::init(const config_type*)
+{
+
+  // power on the oscillator.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::syscon_sysahbclkctrl,
+                               mcal::reg::syscon_clock_wdg>::reg_or();
+
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::wdt_mod,
+                               UINT32_C(0)>::reg_set();
+
+  // Setup WDT clocking.
+
+  // power off wdtosc.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                               mcal::reg::syscon_pdruncfg,
+                               mcal::reg::syscon_pdruncfg_wdtosc_pd_bpos>::bit_set();
+
+  // setup osc
+  mcal::osc::set_wdt_osc(mcal::config::wdt_osc_freq, mcal::config::wdt_osc_div);
+
+  // power on wdtosc.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                               mcal::reg::syscon_pdruncfg,
+                               mcal::reg::syscon_pdruncfg_wdtosc_pd_bpos>::bit_clr();
+
+  // set watchdog OSC for WDT clock source.
+  mcal::osc::set_wdt_clk_src(mcal::osc::wdtclksrc_wdtosc, mcal::config::wdt_clk_div);
+
+
+  // Set watchdog feed time constant.
+  uint32_t wdt_freq = mcal::osc::get_wdt_osc_rate() / mcal::config::wdt_hz;
+
+  // Set Timer Constant.
+  mcal::reg::reg_access_dynamic<std::uint32_t, std::uint32_t>::reg_set(mcal::reg::wdt_tc, wdt_freq);
+
+
+	// Clear watchdog peripheral interrupt.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                               mcal::reg::wdt_mod,
+                               wdmod_wdtof_bpos>::bit_clr();
+
+	// Clear pending watchdog interrupt.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                               mcal::reg::nvic_icpr,
+                               (1 << mcal::irq::wdt_irqn)>::reg_set();
+
+  // Set enable watchdog interrupt.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                               mcal::reg::nvic_iser,
+                               (1 << mcal::irq::wdt_irqn)>::reg_set();
+
+	// Start watchdog.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t,
+                               mcal::reg::wdt_mod,
+                               wdmod_wden_bpos>::bit_set();
+
+  // Feed.
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::wdt_feed,
+                               mcal::wdg::wdt_feed_seq_1>::reg_set();
+
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::wdt_feed,
+                               mcal::wdg::wdt_feed_seq_2>::reg_set();
+}
+
+void mcal::wdg::secure::trigger()
+{
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::wdt_feed,
+                               mcal::wdg::wdt_feed_seq_1>::reg_set();
+
+  mcal::reg::reg_access_static<std::uint32_t, std::uint32_t, 
+                               mcal::reg::wdt_feed,
+                               mcal::wdg::wdt_feed_seq_2>::reg_set();
+}

--- a/ref_app/src/mcal/lpc11c24/mcal_wdg.h
+++ b/ref_app/src/mcal/lpc11c24/mcal_wdg.h
@@ -1,0 +1,46 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Copyright Joel Winarske 2019.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef MCAL_WDG_2010_04_10_H_
+  #define MCAL_WDG_2010_04_10_H_
+
+  #include <cstdint>
+
+  extern "C" void __my_startup() __attribute__((section(".startup"), used, noinline));
+
+  namespace sys { namespace idle { void task_func(); } }
+
+  namespace mcal
+  {
+    namespace wdg
+    {
+      typedef void config_type;
+
+      void init(const config_type*);
+
+      constexpr std::uint32_t wdmod_wden_bpos      = UINT32_C(0);
+      constexpr std::uint32_t wdmod_wdreset_bpos   = UINT32_C(1);
+      constexpr std::uint32_t wdmod_wdtof_bpos     = UINT32_C(2);
+      constexpr std::uint32_t wdmod_wdint_bpos     = UINT32_C(3);
+      constexpr std::uint32_t wdmod_wdprotect_bpos = UINT32_C(3);
+
+      constexpr std::uint32_t wdt_feed_seq_1       = UINT32_C(0xAA);
+      constexpr std::uint32_t wdt_feed_seq_2       = UINT32_C(0x55);
+
+      class secure final
+      {
+        static void trigger();
+
+        friend void __wdt_handler() __attribute__((interrupt));
+        friend void ::sys::idle::task_func();
+        friend void ::__my_startup();
+      };
+    }
+  }
+
+#endif // MCAL_WDG_2010_04_10_H_

--- a/ref_app/target/micros/lpc11c24/make/lpc11c24.ld
+++ b/ref_app/target/micros/lpc11c24/make/lpc11c24.ld
@@ -1,0 +1,99 @@
+
+/*
+ Copyright Christopher Kormanyos 2007 - 2018.
+ Distributed under the Boost Software License,
+ Version 1.0. (See accompanying file LICENSE_1_0.txt
+ or copy at http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+/* Linker script for LPC11C24/301 ARM(R) Cortex(TM)-M0 MCU */
+
+INPUT(libc.a libm.a libgcc.a)
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-littlearm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+
+/* The beginning and end of the program ROM area */
+_rom_begin = 0x00000000;
+_rom_end   = 0x00007FFC;
+
+/* The beginning and end (i.e., top) of the stack */
+/* Set up a stack with a size of 2K */
+_stack_begin = 0x10001800;
+_stack_end   = 0x10002000;
+
+__initial_stack_pointer = 0x10002000;
+
+MEMORY
+{
+  ROM(rx)  : ORIGIN = 0x00000000, LENGTH = 32K
+  RAM(rwx) : ORIGIN = 0x10000000, LENGTH = 8k
+}
+
+SECTIONS
+{
+  . = 0x00000000;
+  . = ALIGN(4);
+
+  /* ISR vectors */
+  .isr_vector :
+  {
+    *(.isr_vector)
+    . = ALIGN(0x100);
+    KEEP(*(.isr_vector))
+  } > ROM = 0xAAAA
+
+  /* Program code (text), read-only data and static ctors */
+  .text :
+  {
+    _ctors_begin = .;
+    *(.init_array)
+    . = ALIGN(4);
+    KEEP (*(SORT(.init_array)))
+    _ctors_end = .;
+    *(.text)
+    . = ALIGN(4);
+    *(.text*)
+    . = ALIGN(4);
+    *(.rodata)
+    . = ALIGN(4);
+    *(.rodata*)
+    . = ALIGN(4);
+  } > ROM
+
+  .text :
+  {
+    . = ALIGN(0x10);
+  } > ROM = 0xAAAA
+
+  . = 0x20000000;
+  . = ALIGN(4);
+
+  /* The ROM-to-RAM initialized data section */
+  .data :
+  {
+    _data_begin = .;
+    *(.data)
+    . = ALIGN(4);
+    KEEP (*(.data))
+    *(.data*)
+    . = ALIGN(4);
+    KEEP (*(.data*))
+    _data_end = .;
+  } > RAM AT > ROM
+
+  /* The uninitialized (zero-cleared) data section */
+  .bss :
+  {
+    _bss_begin = .;
+    *(.bss)
+    . = ALIGN(4);
+    KEEP (*(.bss))
+    *(.bss*)
+    . = ALIGN(4);
+    KEEP (*(.bss*))
+    _bss_end = .;
+  } > RAM
+
+  _rom_data_begin = LOADADDR(.data);
+}

--- a/ref_app/target/micros/lpc11c24/make/lpc11c24_files.gmk
+++ b/ref_app/target/micros/lpc11c24/make/lpc11c24_files.gmk
@@ -1,0 +1,19 @@
+#
+#  Copyright Christopher Kormanyos 2007 - 2018.
+#  Distributed under the Boost Software License,
+#  Version 1.0. (See accompanying file LICENSE_1_0.txt
+#  or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# ------------------------------------------------------------------------------
+# File list of the stm32f100 files in the project
+# ------------------------------------------------------------------------------
+
+FILES_TGT  = $(PATH_APP)/util/STD_LIBC/memory                          \
+             $(PATH_APP)/util/STL/impl/arm/arm_float_limits            \
+             $(PATH_APP)/util/STL/impl/cmath_impl_gamma                \
+             $(PATH_APP)/util/STL/impl/cmath_impl_hyperbolic           \
+             $(PATH_TGT)/startup/crt0                                  \
+             $(PATH_TGT)/startup/crt0_init_ram                         \
+             $(PATH_TGT)/startup/crt1                                  \
+             $(PATH_TGT)/startup/int_vect

--- a/ref_app/target/micros/lpc11c24/make/lpc11c24_flags.gmk
+++ b/ref_app/target/micros/lpc11c24/make/lpc11c24_flags.gmk
@@ -1,0 +1,34 @@
+#  Copyright Christopher Kormanyos 2007 - 2018.
+#  Distributed under the Boost Software License,
+#  Version 1.0. (See accompanying file LICENSE_1_0.txt
+#  or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+
+# ------------------------------------------------------------------------------
+# compiler flags for the target architecture
+# ------------------------------------------------------------------------------
+
+GCC_VERSION   = 8.2.1
+GCC_TARGET    = arm-none-eabi
+
+TGT_CFLAGS    = -Os                                            \
+                -finline-functions                             \
+                -finline-limit=32                              \
+                -mcpu=cortex-m0                                \
+                -mtune=cortex-m0                               \
+                -mthumb                                        \
+                -mfloat-abi=soft                               \
+                -mno-unaligned-access                          \
+                -mno-long-calls
+
+
+TGT_CPPFLAGS  = -std=c++17
+
+TGT_INCLUDES  = -I$(PATH_APP)/util/STL_C++XX_stdfloat          \
+                -I$(PATH_APP)/util/STL
+
+TGT_AFLAGS    =
+
+TGT_LDFLAGS   =
+
+IMAGE_FILE    = dummy.foo

--- a/ref_app/target/micros/lpc11c24/startup/crt0.cpp
+++ b/ref_app/target/micros/lpc11c24/startup/crt0.cpp
@@ -1,0 +1,50 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// STM32 EABI ARM(R) Cortex-M3(TM) startup code.
+// Expressed with C++ for STM32F100 by Chris.
+
+#include <mcal/mcal.h>
+
+namespace crt
+{
+  void init_ram();
+  void init_ctors();
+}
+
+extern "C" void __my_startup() __attribute__((used, noinline));
+
+void __my_startup()
+{
+  // Load the stack pointer.
+  // The stack pointer is automatically loaded from
+  // the base position of the interrupt vector table.
+  // So do nothing here.
+
+  // Chip init: Watchdog, port, and oscillator.
+  mcal::cpu::init();
+
+  // Initialize statics from ROM to RAM.
+  // Zero-clear default-initialized static RAM.
+  crt::init_ram();
+  mcal::wdg::secure::trigger();
+
+  // Call all ctor initializations.
+  crt::init_ctors();
+  mcal::wdg::secure::trigger();
+
+  // Jump to main (and never return).
+  asm volatile("ldr r3, =main");
+  asm volatile("blx r3");
+
+  // Catch an unexpected return from main.
+  for(;;)
+  {
+    // Replace with a loud error if desired.
+    mcal::wdg::secure::trigger();
+  }
+}

--- a/ref_app/target/micros/lpc11c24/startup/crt0_init_ram.cpp
+++ b/ref_app/target/micros/lpc11c24/startup/crt0_init_ram.cpp
@@ -1,0 +1,44 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+extern "C"
+{
+  extern std::uintptr_t _rom_data_begin; // Start address for the initialization values of the rom-to-ram section.
+  extern std::uintptr_t _data_begin;     // Start address for the .data section.
+  extern std::uintptr_t _data_end;       // End address for the .data section.
+  extern std::uintptr_t _bss_begin;      // Start address for the .bss section.
+  extern std::uintptr_t _bss_end;        // End address for the .bss section.
+}
+
+namespace crt
+{
+  void init_ram();
+}
+
+void crt::init_ram()
+{
+  typedef std::uint32_t memory_aligned_type;
+
+  // Copy the data segment initializers from ROM to RAM.
+  // Note that all data segments are aligned by 4.
+  const std::size_t size = std::size_t(  static_cast<const memory_aligned_type*>(static_cast<const void*>(&_data_end))
+                                       - static_cast<const memory_aligned_type*>(static_cast<const void*>(&_data_begin)));
+
+  std::copy(static_cast<const memory_aligned_type*>(static_cast<const void*>(&_rom_data_begin)),
+            static_cast<const memory_aligned_type*>(static_cast<const void*>(&_rom_data_begin)) + size,
+            static_cast<      memory_aligned_type*>(static_cast<      void*>(&_data_begin)));
+
+  // Clear the bss segment.
+  // Note that the bss segment is aligned by 4.
+  std::fill(static_cast<memory_aligned_type*>(static_cast<void*>(&_bss_begin)),
+            static_cast<memory_aligned_type*>(static_cast<void*>(&_bss_end)),
+            static_cast<memory_aligned_type>(0U));
+}

--- a/ref_app/target/micros/lpc11c24/startup/crt1.cpp
+++ b/ref_app/target/micros/lpc11c24/startup/crt1.cpp
@@ -1,0 +1,36 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <algorithm>
+#include <iterator>
+
+extern "C"
+{
+  struct ctor_type
+  {
+    typedef void(*function_type)();
+    typedef std::reverse_iterator<const function_type*> const_reverse_iterator;
+  };
+
+  extern ctor_type::function_type _ctors_end[];
+  extern ctor_type::function_type _ctors_begin[];
+}
+
+namespace crt
+{
+  void init_ctors();
+}
+
+void crt::init_ctors()
+{
+  std::for_each(ctor_type::const_reverse_iterator(_ctors_end),
+                ctor_type::const_reverse_iterator(_ctors_begin),
+                [](const ctor_type::function_type pf)
+                {
+                  pf();
+                });
+}

--- a/ref_app/target/micros/lpc11c24/startup/int_vect.cpp
+++ b/ref_app/target/micros/lpc11c24/startup/int_vect.cpp
@@ -1,0 +1,90 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright Christopher Kormanyos 2007 - 2013.
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <array>
+#include <cstddef>
+#include <mcal_cpu.h>
+
+extern "C" void __initial_stack_pointer();
+
+extern "C" void __my_startup         () __attribute__((used, noinline));
+extern "C" void __vector_unused_irq  () __attribute__((used, noinline));
+extern "C" void __nmi_handler        () __attribute__((used, noinline));
+extern "C" void __hard_fault_handler () __attribute__((used, noinline));
+extern "C" void __svc_handler        () __attribute__((used, noinline));
+extern "C" void __pend_sv_handler    () __attribute__((used, noinline));
+extern "C" void __sys_tick_handler   ();
+extern "C" void __wdt_handler        ();
+
+extern "C" void __vector_unused_irq  () { for(;;) { mcal::cpu::nop(); } }
+extern "C" void __nmi_handler        () { for(;;) { mcal::cpu::nop(); } }
+extern "C" void __hard_fault_handler () { for(;;) { mcal::cpu::nop(); } }
+extern "C" void __svc_handler        () { for(;;) { mcal::cpu::nop(); } }
+extern "C" void __pend_sv_handler    () { for(;;) { mcal::cpu::nop(); } }
+
+namespace
+{
+  typedef void(*isr_type)();
+
+  constexpr std::size_t number_of_interrupts = 48U;
+}
+
+extern "C"
+const volatile std::array<isr_type, number_of_interrupts> __isr_vector __attribute__((section(".isr_vector")));
+
+extern "C"
+const volatile std::array<isr_type, number_of_interrupts> __isr_vector =
+{{
+  __initial_stack_pointer,   // 0x0000, initial stack pointer,
+  __my_startup,              // 0x0004, reset,
+  __nmi_handler,             // 0x0008, nmi exception,
+  __hard_fault_handler,      // 0x000C, hard fault exception,
+  __vector_unused_irq,       // 0x0010, memory management exception,
+  __vector_unused_irq,       // 0x0014, bus fault exception,
+  __vector_unused_irq,       // 0x0018, usage fault exception,
+  __vector_unused_irq,       // 0x001C, reserved,
+  __vector_unused_irq,       // 0x0020, reserved,
+  __vector_unused_irq,       // 0x0024, reserved,
+  __vector_unused_irq,       // 0x0028, reserved,
+  __svc_handler,             // 0x002C, svc handler,
+  __vector_unused_irq,       // 0x0030, reserved,
+  __vector_unused_irq,       // 0x0034, reserved,
+  __pend_sv_handler,         // 0x0038, pending svc,
+  __sys_tick_handler,        // 0x003C, system tick handler,
+  __vector_unused_irq,       // 0x0040, GPIO port 0, pin 0 irq handler,
+  __vector_unused_irq,       // 0x0044, GPIO port 0, pin 1 irq handler,
+  __vector_unused_irq,       // 0x0048, GPIO port 0, pin 2 irq handler,
+  __vector_unused_irq,       // 0x004C, GPIO port 0, pin 3 irq handler,
+  __vector_unused_irq,       // 0x0050, GPIO port 0, pin 4 irq handler,
+  __vector_unused_irq,       // 0x0054, GPIO port 0, pin 5 irq handler,
+  __vector_unused_irq,       // 0x0058, GPIO port 0, pin 6 irq handler,
+  __vector_unused_irq,       // 0x005C, GPIO port 0, pin 7 irq handler,
+  __vector_unused_irq,       // 0x0060, GPIO port 0, pin 8 irq handler,
+  __vector_unused_irq,       // 0x0064, GPIO port 0, pin 9 irq handler,
+  __vector_unused_irq,       // 0x0068, GPIO port 0, pin 10 irq handler,
+  __vector_unused_irq,       // 0x006C, GPIO port 0, pin 11 irq handler,
+  __vector_unused_irq,       // 0x0070, GPIO port 1, pin 0 irq handler,
+  __vector_unused_irq,       // 0x0074, C_CAN irq handler,
+  __vector_unused_irq,       // 0x0078, SSP1 irq handler,
+  __vector_unused_irq,       // 0x007C, I2C irq handler,
+  __vector_unused_irq,       // 0x0080, 16-bit Timer0 irq handler,
+  __vector_unused_irq,       // 0x0084, 16-bit Timer1 irq handler,
+  __vector_unused_irq,       // 0x0088, 32-bit Timer0 irq handler,
+  __vector_unused_irq,       // 0x008C, 32-bit Timer1 irq handler,
+  __vector_unused_irq,       // 0x0090, SSP0 irq handler,
+  __vector_unused_irq,       // 0x0094, UART irq handler,
+  __vector_unused_irq,       // 0x0098, reserved,
+  __vector_unused_irq,       // 0x009C, reserved,
+  __vector_unused_irq,       // 0x00A0, A/D Converter irq handler,
+  __wdt_handler,             // 0x00A4, Watchdog timer irq handler,
+  __vector_unused_irq,       // 0x00A8, Brown Out Detect(BOD) irq handler,
+  __vector_unused_irq,       // 0x00AC, reserved,
+  __vector_unused_irq,       // 0x00B0, External Interrupt 3 irq handler,
+  __vector_unused_irq,       // 0x00B4, External Interrupt 2 irq handler,
+  __vector_unused_irq,       // 0x00B8, External Interrupt 1 irq handler,
+  __vector_unused_irq        // 0x00BC, External Interrupt 0 irq handler,
+}};


### PR DESCRIPTION
Expects crystal oscillator @ 12MHz, as used on the NXP board.

PLL output freq is configured for 48MHz.


I'm open to any and all changes...

Cheers,
Joel