### PR TITLE
Target=Host: Remove -m32 for non MINGW builds

### DIFF
--- a/ref_app/cmake/host.cmake
+++ b/ref_app/cmake/host.cmake
@@ -50,10 +50,6 @@ else()
             -mtune=native
         )
 
-        if(NOT MINGW)
-            list(APPEND _TARGET_CFLAGS -m32) # force 32-bit compilation
-        endif()
-
         set(TARGET_AFLAGS "")
 
         set(_TARGET_LDFLAGS -pthread)


### PR DESCRIPTION
Remove -m32 (32 bit compile) for non MINGW builds.

Update to typedef std::uint64_t value_type in mcal_gpt.h resolves this.