### PR TITLE
some tweaks after building ref_app with cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ref_app/tmp/
 ref_app/x64
 ref_app/bin/
 examples/chapter*/bin
+build

--- a/readme.md
+++ b/readme.md
@@ -297,7 +297,7 @@ cd real-time-cpp
 mkdir build
 cd build
 cmake ../ref_app -DTRIPLE=avr -DTARGET=avr -DCMAKE_TOOLCHAIN_FILE=../ref_app/cmake/gcc-toolchain.cmake
-make -j ref_app
+cmake --build .
 ```
 
 We will now consider, for instance, building the reference application for
@@ -322,7 +322,7 @@ cd real-time-cpp
 mkdir build
 cd build
 cmake ../ref_app -DTRIPLE=arm-none-eabi -DTARGET=stm32f446 -DCMAKE_TOOLCHAIN_FILE=../ref_app/cmake/gcc-toolchain.cmake
-make -j ref_app
+cmake --build .
 ```
 
 When building with CMake for other targets,
@@ -339,7 +339,7 @@ cd real-time-cpp
 mkdir build
 cd build
 cmake ../ref_app -DTARGET=host -DCMAKE_TOOLCHAIN_FILE=../ref_app/cmake/gcc-toolchain.cmake
-make -j ref_app
+cmake --build .
 ```
 
 ### Build with MICROCHIP's ATMEL Studio

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,4 @@
-﻿Real-Time-C++
-==================
+﻿# Real-Time-C++
 
 <p align="center">
     <a href="https://github.com/ckormanyos/real-time-cpp/actions">
@@ -511,8 +510,8 @@ The multicore system first boots core0 which subsequently
 starts up core1 and also starts up the RISC-V-ULP coprocessor core.
 Blinky runs in the standard `ref_app`
 on core0 toggling `port7` while an endless timer loop on core1
-toggles `port6`. These LED ports togle in near unison
-at the normal blinky feequency of $\frac{1}{2}~\text{Hz}$.
+toggles `port6`. These LED ports toggle in near unison
+at the normal blinky frequency of $\frac{1}{2}~\text{Hz}$.
 The RISC-V-ULP coprocessor performs an LED dimming
 show on `port17` at a randomly chosen frequency
 that is asynchronous to the regular blinky show.
@@ -580,7 +579,7 @@ and the oscilloscope captures
 a real-time measurement of the benchmark's time signal
 on digital I/O `port1.15`, header pin `P8.15` of the BBB.
 
-![](./images/bare_metal_bbb.jpg)
+![BeagleBone Black Baremetal example](./images/bare_metal_bbb.jpg)
 
 ## Continuous Integration (CI)
 


### PR DESCRIPTION
Hi there Christopher!

Here are some minor tweaks I came up with while playing around with the reference app.

Building with `cmake --build` is more generic, and will work regardless of the default generator used for configuration. In my case, default generator was Ninja, on my Windows environment. Building with `make` wasn't valid for me, and confused me a bit at first, when following the build instructions.

On a personal note, I wanted to share with you that I've recently finished your book, and also landed a new job as a C++ Software Engineer, working in applications with a strong focus on real-time performance. It has been an important step in my career and I'm very exited about it! I think your book has played an important part in this, giving me both the knowledge and confidence I needed to land the job. For this reason, I wanted to say again: thank you! 

While going through the book I found a few typos which I noted down. I'm not aware if you're working on a fifth edition, but if you are interested, let me know and I'll make a summary and email it to you.

